### PR TITLE
French translation

### DIFF
--- a/1.6/Languages/French/Keyed/Keys.xml
+++ b/1.6/Languages/French/Keyed/Keys.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LanguageData>
+    <LSE_LaunchSiteTimeoutDaysLabel>Les sites de lancement expirent après {0} jour(s)</LSE_LaunchSiteTimeoutDaysLabel>
+    <LSE_LaunchSiteTimeoutDaysTooltip>Combien de temps les nouveaux sites de lancement doivent-ils rester sur la carte? 30 jours par défaut.</LSE_LaunchSiteTimeoutDaysTooltip>
+    <LSE_LandmarkSitesCanExpireLabel>Les sites de lancement sur les tuiles avec des particularités de terrain peuvent-ils expirer?</LSE_LandmarkSitesCanExpireLabel>
+    <LSE_LandmarkSitesCanExpireTooltip>Les sites de lancement peuvent-ils expirer même s’ils sont situés sur une tuile avec des particularités de terrain? Désactivé par défaut.</LSE_LandmarkSitesCanExpireTooltip>
+    <LSE_AbandonedTimeoutDaysLabel>Les camps abandonnés expirent après {0} jour(s)</LSE_AbandonedTimeoutDaysLabel>
+    <LSE_AbandonedCampTimeoutDaysTooltip>Combien de temps les camps abandonnés doivent-ils rester sur la carte? 30 jours par défaut.</LSE_AbandonedCampTimeoutDaysTooltip>
+    <LSE_LandmarkCampsCanExpireLabel>Les camps abandonnés sur les tuiles avec des particularités de terrain peuvent-ils expirer?</LSE_LandmarkCampsCanExpireLabel>
+    <LSE_LandmarkCampsCanExpireTooltip>Les camps abandonnés peuvent-ils expirer même s’ils sont situés sur une tuile avec des particularités de terrain? Désactivé par défaut.</LSE_LandmarkCampsCanExpireTooltip>
+</LanguageData>


### PR DESCRIPTION
* **Landmarks**: "Landmarks" can't really be translated into French. "tuiles avec des particularités de terrain" is appropriate. The word "tile" is often used in tile-based video games.
* **Curly quote**: Instead of using a quotation mark for an apostrophe, a curly quotation mark was used. This is safer in XML files, and is a common practice in French writing.

It's been tested (1920x1080 and 1366x768). No visual overflow, and no incorrectly displayed characters. All tooltips display correctly.

<img width="1130" height="880" alt="screenshot" src="https://github.com/user-attachments/assets/fa31b2af-3b19-4ebb-ad06-bb48260cb5e4" />